### PR TITLE
prevent formDefaults undesired mutation

### DIFF
--- a/src/routes/[username]/edit/+page.svelte
+++ b/src/routes/[username]/edit/+page.svelte
@@ -26,7 +26,7 @@
       title: "",
       url: "https://",
     };
-    const formData = writable(formDefaults);
+    const formData = writable({...formDefaults});
   
     let showForm = false;
   
@@ -50,11 +50,7 @@
         }),
       });
   
-      formData.set({
-        icon: "",
-        title: "",
-        url: "",
-      });
+      formData.set({...formDefaults});
   
       showForm = false;
     }
@@ -74,7 +70,7 @@
     }
   
     function cancelLink() {
-      formData.set(formDefaults);
+      formData.set({...formDefaults});
       showForm = false;
     }
   </script>


### PR DESCRIPTION
For some reason, when on cancelLink(), the fields are not correctly reset.
Also when submitting, the defaults should be populated again.